### PR TITLE
fix: correct SBOM image name for case sensitivity

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,7 +130,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: spdx-json
           output-file: sbom.spdx.json
 


### PR DESCRIPTION
## Summary

- Fix SBOM generation by using the actual pushed image name from Docker metadata
- Resolve case sensitivity mismatch between GitHub repository name (`Flawless/bun-ai-backend-template`) and container registry name (`ghcr.io/flawless/bun-ai-backend-template`)
- Use `fromJSON(steps.meta.outputs.json).tags[0]` to get the correct lowercase image name

## Problem

SBOM generation was failing because:
- GitHub repo: `Flawless/bun-ai-backend-template` (mixed case)  
- Container registry: `ghcr.io/flawless/bun-ai-backend-template` (lowercase)
- SBOM was trying to scan non-existent mixed case image

## Solution

Use the actual pushed image name from Docker metadata instead of manually constructing it.

## Test plan

- [x] SBOM generation should now use correct lowercase image name
- [ ] Verify SBOM step completes successfully on master after merge

🤖 Generated with [Claude Code](https://claude.ai/code)